### PR TITLE
switch to public repos for commit history

### DIFF
--- a/components/git.tsx
+++ b/components/git.tsx
@@ -51,10 +51,9 @@ export const GitHistory: React.FC<GitHistoryProps> = ({
       setIsRefreshing(true);
       try {
         const response = await fetch(
-          "https://api.github.com/user/repos?per_page=100",
+          `https://api.github.com/users/${process.env.NEXT_PUBLIC_GITHUB_USERNAME}/repos?per_page=100&type=public`,
           {
             headers: {
-              Authorization: `token ${process.env.NEXT_PUBLIC_GITHUB_TOKEN}`,
               Accept: "application/vnd.github.v3+json",
             },
           }
@@ -79,7 +78,6 @@ export const GitHistory: React.FC<GitHistoryProps> = ({
                 `https://api.github.com/repos/${repo.full_name}/commits?per_page=25`,
                 {
                   headers: {
-                    Authorization: `token ${process.env.NEXT_PUBLIC_GITHUB_TOKEN}`,
                     Accept: "application/vnd.github.v3+json",
                   },
                 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Switch `GitHistory` component to fetch public repositories from GitHub without authorization token.
> 
>   - **Behavior**:
>     - Modify GitHub API request in `GitHistory` component to fetch public repositories using `https://api.github.com/users/${process.env.NEXT_PUBLIC_GITHUB_USERNAME}/repos?per_page=100&type=public`.
>     - Remove `Authorization` header from API requests in `git.tsx`.
>   - **Misc**:
>     - Adjust error handling to reflect changes in API request structure.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=alanagoyal%2Fbasecase.sh&utm_source=github&utm_medium=referral)<sup> for fb1bf9331fb10a316c86d8da69f5f81bfd79be44. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->